### PR TITLE
Add missing dependencies to nheko-0.2.0.ebuild

### DIFF
--- a/net-im/nheko/nheko-0.2.0.ebuild
+++ b/net-im/nheko/nheko-0.2.0.ebuild
@@ -21,6 +21,8 @@ IUSE=""
 RDEPEND=">=dev-qt/qtgui-5.7.1
 		>=dev-qt/qtnetwork-5.7.1
 		>=dev-qt/linguist-tools-5.7.1
+		>=dev-qt/qtwidgets-5.7.0
+		dev-qt/qtconcurrent
 		dev-qt/qtmultimedia
 		media-libs/fontconfig
 		dev-db/lmdb"


### PR DESCRIPTION
\>=dev-qt/qtwidgets-5.7.0 and dev-qt/qtconcurrent are required to build nheko-0.2.0. Not sure about the other versions.